### PR TITLE
fix long decode/encode

### DIFF
--- a/src/coding/long.rs
+++ b/src/coding/long.rs
@@ -41,7 +41,7 @@ impl Encodeable for Long {
         for i in 1..=8 {
             let byte = (value & 0b11111111) as u8;
             if i != 8 {
-                value = value >> 8;
+                value >>= 8;
             }
             result.push_front(byte);
         }

--- a/src/coding/long.rs
+++ b/src/coding/long.rs
@@ -13,7 +13,7 @@ impl Decodeable<Long, io::Error> for VecDeque<u8> {
             let byte = self.pop_front().expect("Vector needs to have 8 bytes to decode a long(i64).") as u64;
             temp += byte;
             if i != 8 {
-                temp = temp << 8;
+                temp <<= 8;
             }
             
         }


### PR DESCRIPTION
Uhm. I don't know if its right now but I definitly fixed something... :grin: 
Minecraft uses "Signed 64-bit integer, two's complement " so as I see that, the test down in this file had wrong values (referring to [Two's complement](https://en.wikipedia.org/wiki/Two%27s_complement)).

Anyway, there were too many bit-shifts in your original code that caused the main issue. That was not a big problem, but there was one more thing that really challenged me: Rust seems to be using other formats for signed numbers. The sign bit is not the most but the least significant bit... :thinking: 
So what I did was to take the absolute value from the Long checked via [Signed](https://rust-num.github.io/num/num/trait.Signed.html) if the Long was originally positive or negative. If it was positive, I just continued with the absolute value. Though if it was negative, I flipped all the bits and added a sign bit as the most significant bit.