### PR TITLE
add float de-/encoding

### DIFF
--- a/src/coding/float.rs
+++ b/src/coding/float.rs
@@ -33,7 +33,7 @@ impl Decodeable<MinecraftFloat, io::Error> for VecDeque<u8> {
         let byte = get_byte_or_fail(self)? as u32;
         temp += byte;
 
-        let mut result: MinecraftFloat = f32::from_bits(temp);
+        let result: MinecraftFloat = f32::from_bits(temp);
         Ok(result)
     }
 }

--- a/src/coding/float.rs
+++ b/src/coding/float.rs
@@ -1,0 +1,97 @@
+use super::{Decodeable, Encodeable};
+use std::collections::VecDeque;
+use std::f32;
+use std::io;
+
+pub type Float = f32;
+
+impl Decodeable<Float, io::Error> for VecDeque<u8> {
+    fn decode(&mut self) -> Result<Float, io::Error> {
+        let mut temp: u32 = 0;
+
+        #[inline(always)]
+        fn get_byte_or_fail(vector: &mut VecDeque<u8>) -> Result<u8, io::Error> {
+            let value = vector.pop_front();
+
+            if value.is_some() {
+                Ok(value.unwrap())
+            } else {
+                Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "Not enough bytes to decode a float(f32)!",
+                ))
+            }
+        };
+
+        for _ in 1..=3 {
+            let byte = get_byte_or_fail(self)? as u32;
+            temp += byte;
+            temp <<= 8;
+        }
+
+        // add remaining byte without the shift
+        let byte = get_byte_or_fail(self)? as u32;
+        temp += byte;
+
+        let mut result: Float = f32::from_bits(temp);
+        Ok(result)
+    }
+}
+
+impl Encodeable for Float {
+    fn encode(&self) -> VecDeque<u8> {
+        let mut result: VecDeque<u8> = VecDeque::with_capacity(4);
+        let mut value = f32::to_bits(*self);
+        
+        for _ in 1..=3 {
+            let byte = (value & 0b11111111) as u8;
+            value >>= 8;
+            result.push_front(byte);
+        }
+
+        // add remaining byte without shifting
+        let byte = (value & 0b11111111) as u8;
+        result.push_front(byte);
+        result
+    }
+
+    fn byte_length(&self) -> u8 {
+        4
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Float;
+    use super::{Decodeable, Encodeable};
+    use std::collections::VecDeque;
+
+    #[test]
+    fn test_read_float_on_vec() {
+        let mappings: Vec<(Float, Vec<u8>)> = vec![
+            (12.5f32, vec![0x41, 0x48, 0, 0]),
+            (-12.5f32, vec![0xC1, 0x48, 0, 0]),
+            (1f32, vec![0x3F, 0x80, 0, 0]),
+            (-1f32, vec![0xBF, 0x80, 0, 0]),
+        ];
+
+        for mapping in mappings {
+            let actual: Float = VecDeque::from(mapping.1).decode().unwrap();
+
+            assert_eq!(mapping.0, actual);
+        }
+    }
+    #[test]
+    fn test_write_float_to_vec() {
+        let mappings: Vec<(Float, Vec<u8>)> = vec![
+            (12.5f32, vec![0x41, 0x48, 0, 0]),
+            (-12.5f32, vec![0xC1, 0x48, 0, 0]),
+            (1f32, vec![0x3F, 0x80, 0, 0]),
+            (-1f32, vec![0xBF, 0x80, 0, 0]),
+        ];
+
+        for mapping in mappings {
+            assert_eq!(VecDeque::from(mapping.1), mapping.0.encode());
+        }
+    }
+}

--- a/src/coding/float.rs
+++ b/src/coding/float.rs
@@ -51,6 +51,7 @@ impl Encodeable for MinecraftFloat {
 
         // add remaining byte without shifting
         let byte = (value & 0b11111111) as u8;
+        
         result.push_front(byte);
         result
     }

--- a/src/coding/float.rs
+++ b/src/coding/float.rs
@@ -3,10 +3,10 @@ use std::collections::VecDeque;
 use std::f32;
 use std::io;
 
-pub type Float = f32;
+pub type MinecraftFloat = f32;
 
-impl Decodeable<Float, io::Error> for VecDeque<u8> {
-    fn decode(&mut self) -> Result<Float, io::Error> {
+impl Decodeable<MinecraftFloat, io::Error> for VecDeque<u8> {
+    fn decode(&mut self) -> Result<MinecraftFloat, io::Error> {
         let mut temp: u32 = 0;
 
         #[inline(always)]
@@ -18,7 +18,7 @@ impl Decodeable<Float, io::Error> for VecDeque<u8> {
             } else {
                 Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
-                    "Not enough bytes to decode a float(f32)!",
+                    "Not enough bytes to decode a MinecraftFloat(f32)!",
                 ))
             }
         };
@@ -33,12 +33,12 @@ impl Decodeable<Float, io::Error> for VecDeque<u8> {
         let byte = get_byte_or_fail(self)? as u32;
         temp += byte;
 
-        let mut result: Float = f32::from_bits(temp);
+        let mut result: MinecraftFloat = f32::from_bits(temp);
         Ok(result)
     }
 }
 
-impl Encodeable for Float {
+impl Encodeable for MinecraftFloat {
     fn encode(&self) -> VecDeque<u8> {
         let mut result: VecDeque<u8> = VecDeque::with_capacity(4);
         let mut value = f32::to_bits(*self);
@@ -62,13 +62,13 @@ impl Encodeable for Float {
 
 #[cfg(test)]
 mod tests {
-    use super::Float;
+    use super::MinecraftFloat;
     use super::{Decodeable, Encodeable};
     use std::collections::VecDeque;
 
     #[test]
     fn test_read_float_on_vec() {
-        let mappings: Vec<(Float, Vec<u8>)> = vec![
+        let mappings: Vec<(MinecraftFloat, Vec<u8>)> = vec![
             (12.5f32, vec![0x41, 0x48, 0, 0]),
             (-12.5f32, vec![0xC1, 0x48, 0, 0]),
             (1f32, vec![0x3F, 0x80, 0, 0]),
@@ -76,14 +76,14 @@ mod tests {
         ];
 
         for mapping in mappings {
-            let actual: Float = VecDeque::from(mapping.1).decode().unwrap();
+            let actual: MinecraftFloat = VecDeque::from(mapping.1).decode().unwrap();
 
             assert_eq!(mapping.0, actual);
         }
     }
     #[test]
     fn test_write_float_to_vec() {
-        let mappings: Vec<(Float, Vec<u8>)> = vec![
+        let mappings: Vec<(MinecraftFloat, Vec<u8>)> = vec![
             (12.5f32, vec![0x41, 0x48, 0, 0]),
             (-12.5f32, vec![0xC1, 0x48, 0, 0]),
             (1f32, vec![0x3F, 0x80, 0, 0]),

--- a/src/coding/mod.rs
+++ b/src/coding/mod.rs
@@ -9,6 +9,7 @@ pub mod gamemode;
 pub mod int;
 pub mod level_type;
 pub mod long;
+pub mod float;
 pub mod short;
 pub mod string;
 pub mod varint;

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -262,6 +262,18 @@ impl Connection {
             packet.send(&mut self.tcp_stream)?;
 
             // TODO: S->C Player Abilities Packet
+
+            // Test Player Abilities Packet
+            // let mut packet = Packet::from_id_and_data( 
+            //     Varint(0x2E),
+            //     PacketData::Data(super::build_package_data!(
+            //         0b1101i8,
+            //         0.5f32,
+            //         0.5f32
+            //     )),
+            // );
+            // packet.send(&mut self.tcp_stream)?;
+
         }
 
         Ok(())

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -261,18 +261,15 @@ impl Connection {
 
             packet.send(&mut self.tcp_stream)?;
 
-            // TODO: S->C Player Abilities Packet
-
-            // Test Player Abilities Packet
-            // let mut packet = Packet::from_id_and_data( 
-            //     Varint(0x2E),
-            //     PacketData::Data(super::build_package_data!(
-            //         0b1101i8,
-            //         0.5f32,
-            //         0.5f32
-            //     )),
-            // );
-            // packet.send(&mut self.tcp_stream)?;
+            let mut packet = Packet::from_id_and_data( 
+                Varint(0x2E),
+                PacketData::Data(super::build_package_data!( // TODO change values to sth. usefull
+                    0b1101i8,
+                    0.5f32,
+                    0.5f32
+                )),
+            );
+            packet.send(&mut self.tcp_stream)?;
 
         }
 


### PR DESCRIPTION
Add float de-/encoding based on Rusts implemented functions `from_bits(v: u32)` and `to_bits(self)` as they claim to be using the same standard as Minecraft uses for floats ("A single-precision 32-bit IEEE 754 floating point number").

I could not extract any test values from Minecraft packets or other sources, but I used common float values for this standard (with the help of [this online converter](http://www.binaryconvert.com/result_float.html)). Maybe there is a way to get real minecraft example values?

**Current status:** tested

#5 